### PR TITLE
Rewrote SequelizeMeta inserts

### DIFF
--- a/bin/runmigration.js
+++ b/bin/runmigration.js
@@ -89,7 +89,7 @@ async function executeSql(queryInterface, sql) {
 }
 
 (async () => {
-  let res = await executeSql(queryInterface, 'select * from "SequelizeMeta"');
+  let res = await executeSql(queryInterface, 'select * from SequelizeMeta');
   let ranMigrations = res.map(r => r.name);
   migrationFiles = migrationFiles.filter(mf => {
     return (!ranMigrations.includes(mf));
@@ -100,7 +100,7 @@ async function executeSql(queryInterface, sql) {
 
   for (let file of migrationFiles) {
     await migrate.executeMigration(queryInterface, path.join(migrationsDir, file), fromPos);
-    await executeSql(queryInterface, `INSERT INTO "SequelizeMeta" ("name") VALUES ('${file}')`);
+    await executeSql(queryInterface, `INSERT INTO SequelizeMeta (name) VALUES ('${file}')`);
     fromPos = 0;
   }
 


### PR DESCRIPTION
Using MariaDB/MySQL, the operations on SequelizeMeta fail as the driver does not expect the name SequelizeMeta to be surrounded by quotation marks. I was using this package in my project and noticed the error message kept getting hung up on quotation marks, so I manually removed them from my local copy to get it running.